### PR TITLE
Add breakline to improve Calendar presentation

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -5,5 +5,6 @@ title: Monero Space
 <div class="blurb">
 	<h1>Monero Community Events Calendar</h1>
   <body>This calendar is updated regularly by members of the Monero Space workroup and other Monero community members.</body>
+  <br>
   <iframe src="https://calendar.google.com/calendar/embed?src=itmaraubkfoe4aq2oquoaogsuk%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 </div><!-- /.blurb -->


### PR DESCRIPTION
Calendar widget is currently on same line as text, causing unnecessary horizontal stretch:
![image](https://user-images.githubusercontent.com/3056597/118010482-9e4b2080-b33e-11eb-8d73-744f777da6f0.png)
